### PR TITLE
[CLOUD-3810] [6.4.x] Remove BZ-1861193.zip patch zip

### DIFF
--- a/modules/eap/6.4.23/install.sh
+++ b/modules/eap/6.4.23/install.sh
@@ -5,5 +5,4 @@ set -e
 SOURCES_DIR=/tmp/artifacts/
 
 $JBOSS_HOME/bin/jboss-cli.sh --command="patch apply $SOURCES_DIR/jboss-eap-6.4.23-patch.zip"
-$JBOSS_HOME/bin/jboss-cli.sh --command="patch apply $SOURCES_DIR/BZ-1861193.zip"
 $JBOSS_HOME/bin/jboss-cli.sh --command="patch apply $SOURCES_DIR/BZ1875177.zip"

--- a/modules/eap/6.4.23/module.yaml
+++ b/modules/eap/6.4.23/module.yaml
@@ -16,9 +16,6 @@ artifacts:
     - name: jboss-eap-6.4.23-patch.zip
       target: jboss-eap-6.4.23-patch.zip
       md5: 66474ea83de005bd019aa9b8f03b21ce
-    - name: BZ-1861193.zip
-      target: BZ-1861193.zip
-      md5: 62880cd655f070c5cebdde7b6dc24b4f
     - name: BZ1875177.zip
       target: BZ1875177.zip
       md5: 685f7b00c482510f5f73519f8006d244


### PR DESCRIPTION
Patch BZ-1861193.zip was incomplete and a new BZ1875177.zip was created with
the complete fix. The BZ1875177.zip was added via commit #d3b56abd69, and is
related to Jira SPMM-2344.

Signed-off-by: Daniel Kreling <dkreling@redhat.com>
