### PR TITLE
set RHEL 7 registry to the correct one

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 name: "jboss-eap-6/eap64"
 description: "Red Hat JBoss Enterprise Application Platform 6.4 container image"
 version: "6.4.23"
-from: "rhel7:7-released"
+from: "registry.redhat.io/rhel7/rhel:latest"
 labels:
     - name: "com.redhat.component"
       value: "jboss-eap-6-eap64-container"


### PR DESCRIPTION
This change is related to CLOUD-3848, which tracked the changes in RHEL7 registry
source in order to build RHEL7 images.

Related PR: https://github.com/jboss-container-images/jboss-eap-7-openshift-image/pull/393 